### PR TITLE
Update to zlib tarball to 1.28

### DIFF
--- a/cmake/avogadro_tarballs.cmake
+++ b/cmake/avogadro_tarballs.cmake
@@ -19,9 +19,9 @@ set(qt_url
 set(qt_md5 "66b992f5c21145df08c99d21847f4fdb")
 
 # Zlib
-set(zlib_version 1.2.7)
+set(zlib_version 1.2.8)
 set(zlib_url "http://zlib.net/zlib-${zlib_version}.tar.gz")
-set(zlib_md5 60df6a37c56e7c1366cca812414f7b85)
+set(zlib_md5 44d667c142d7cda120332623eab69f40)
 
 # libxml2
 set(libxml2_version 2.7.8)


### PR DESCRIPTION
New zlib version is available and the old one got removed from the website again.
